### PR TITLE
Support extended flag values and new area file sections

### DIFF
--- a/area-parser/src/main/kotlin/dd4/areaparser/AreaFileReader.kt
+++ b/area-parser/src/main/kotlin/dd4/areaparser/AreaFileReader.kt
@@ -115,6 +115,25 @@ class AreaFileReader(areaFilePath: Path) : Closeable {
         return unparsed.toInt()
     }
 
+    fun readBits(): ULong {
+        readWhitespace()
+        val firstChar = readChar() ?: throw ParseError("End of file")
+
+        if (!(firstChar.isDigit() || firstChar == '+' || firstChar == '-'))
+            throw ParseError("Expected start of number, found '$firstChar'", this)
+
+        val unparsed = firstChar + readWhile { it.isDigit() || it == Markup.BIT_DELIMITER }
+
+        if (unparsed.contains(Markup.BIT_DELIMITER)) {
+            return unparsed.split(Markup.BIT_DELIMITER)
+                    .filter { it.isNotBlank() }
+                    .map { it.toULong() }
+                    .sum()
+        }
+
+        return unparsed.toULong()
+    }
+
     fun readLetter(): Char {
         readWhitespace()
         return readChar() ?: throw ParseError("End of file")

--- a/area-parser/src/main/kotlin/dd4/areaparser/AreaFileReader.kt
+++ b/area-parser/src/main/kotlin/dd4/areaparser/AreaFileReader.kt
@@ -119,7 +119,7 @@ class AreaFileReader(areaFilePath: Path) : Closeable {
         readWhitespace()
         val firstChar = readChar() ?: throw ParseError("End of file")
 
-        if (!(firstChar.isDigit() || firstChar == '+' || firstChar == '-'))
+        if (!firstChar.isDigit())
             throw ParseError("Expected start of number, found '$firstChar'", this)
 
         val unparsed = firstChar + readWhile { it.isDigit() || it == Markup.BIT_DELIMITER }

--- a/core/src/main/kotlin/dd4/core/file/Markup.kt
+++ b/core/src/main/kotlin/dd4/core/file/Markup.kt
@@ -20,6 +20,8 @@ object Markup {
     const val OBJECT_EXTRA_DESCRIPTION_DELIMITER = 'E'
     const val OBJECT_EFFECT_DELIMITER = 'A'
 
+    const val OBJECT_SET_EFFECT_DELIMITER = 'A'
+
     const val ROOM_DOOR_DELIMITER = 'D'
     const val ROOM_END_OF_SECTION_DELIMITER = 'S'
     const val ROOM_EXTRA_DESCRIPTION_DELIMITER = 'E'
@@ -32,4 +34,8 @@ object Markup {
     const val SPECIAL_FUNCTION_COMMENT_DELIMITER = '*'
 
     const val HELP_END_OF_SECTION_DELIMITER = "$"
+
+    const val GAME_END_OF_SECTION_DELIMITER = 'S'
+    const val GAME_MOBILE_DELIMITER = 'M'
+    const val GAME_COMMENT_DELIMITER = '*'
 }

--- a/core/src/main/kotlin/dd4/core/model/Game.kt
+++ b/core/src/main/kotlin/dd4/core/model/Game.kt
@@ -1,0 +1,9 @@
+package dd4.core.model
+
+/**
+ * Gambling game
+ */
+//TODO: Model is incomplete
+data class Game(
+        val croupierVnum: Int,
+)

--- a/core/src/main/kotlin/dd4/core/model/Item.kt
+++ b/core/src/main/kotlin/dd4/core/model/Item.kt
@@ -60,7 +60,17 @@ data class Item(
         MITHRIL("mithril", 38),
         WHETSTONE("whetstone", 39),
         CRAFT("crafting", 40),
-        SPELLCRAFT("spellcrafting", 41);
+        SPELLCRAFT("spellcrafting", 41),
+        TURRET_MODULE("turret_module", 42),
+        FORGE("forge", 43),
+        ARRESTOR_UNIT("arrestor_unit", 44),
+        DRIVER_UNIT("driver_unit", 45),
+        REFLECTOR_UNIT("reflector_unit", 46),
+        SHIELD_UNIT("shield_unit", 47),
+        DEFENSIVE_TURRET_MODULE("defensive_turret_module", 48),
+        TURRET("turret", 49),
+        COMBAT_PULSE("combat_pulse", 50),
+        DEFENSIVE_PULSE("defensive_pulse", 51);
 
         companion object {
             fun fromId(value: Int) =
@@ -77,74 +87,76 @@ data class Item(
 
     enum class ExtraFlag(
             @JsonValue val tag: String,
-            val bit: Int
+            val bit: ULong
     ) {
-        GLOW("glow", 0x1),
-        HUM("hum", 0x2),
-        EGO("ego", 0x4),
-        ANTI_RANGER("anti_ranger", 0x8),
-        EVIL("evil", 0x10),
-        INVISIBLE("invisible", 0x20),
-        MAGIC("magic", 0x40),
-        NO_DROP("no_drop", 0x80),
-        BLESSED("blessed", 0x100),
-        ANTI_GOOD("anti_good", 0x200),
-        ANTI_EVIL("anti_evil", 0x400),
-        ANTI_NEUTRAL("anti_neutral", 0x800),
-        NO_REMOVE("no_remove", 0x1000),
-        INVENTORY("inventory", 0x2000),
-        POISONED("poisoned", 0x4000),
-        ANTI_MAGE("anti_mage", 0x8000),
-        ANTI_CLERIC("anti_cleric", 0x10000),
-        ANTI_THIEF("anti_thief", 0x20000),
-        ANTI_WARRIOR("anti_warrior", 0x40000),
-        ANTI_PSIONIC("anti_psionic", 0x80000),
-        VORPAL("vorpal", 0x100000),
-        TRAP("trap", 0x200000),
-        DONATED("donated", 0x400000),
-        BLADE_THIRST("blade_thirst", 0x800000),
-        SHARP("sharp", 0x1000000),
-        FORGED("forged", 0x2000000),
-        BODY_PART("body_part", 0x4000000),
-        LANCE("lance", 0x8000000),
-        ANTI_BRAWLER("anti_brawler", 0x10000000),
-        ANTI_SHAPE_SHIFTER("anti_shape_shifter", 0x20000000),
-        BOW("bow", 0x40000000);
+        GLOW("glow", 0x1u),
+        HUM("hum", 0x2u),
+        EGO("ego", 0x4u),
+        ANTI_RANGER("anti_ranger", 0x8u),
+        EVIL("evil", 0x10u),
+        INVISIBLE("invisible", 0x20u),
+        MAGIC("magic", 0x40u),
+        NO_DROP("no_drop", 0x80u),
+        BLESSED("blessed", 0x100u),
+        ANTI_GOOD("anti_good", 0x200u),
+        ANTI_EVIL("anti_evil", 0x400u),
+        ANTI_NEUTRAL("anti_neutral", 0x800u),
+        NO_REMOVE("no_remove", 0x1000u),
+        INVENTORY("inventory", 0x2000u),
+        POISONED("poisoned", 0x4000u),
+        ANTI_MAGE("anti_mage", 0x8000u),
+        ANTI_CLERIC("anti_cleric", 0x10000u),
+        ANTI_THIEF("anti_thief", 0x20000u),
+        ANTI_WARRIOR("anti_warrior", 0x40000u),
+        ANTI_PSIONIC("anti_psionic", 0x80000u),
+        VORPAL("vorpal", 0x100000u),
+        TRAP("trap", 0x200000u),
+        DONATED("donated", 0x400000u),
+        BLADE_THIRST("blade_thirst", 0x800000u),
+        SHARP("sharp", 0x1000000u),
+        FORGED("forged", 0x2000000u),
+        BODY_PART("body_part", 0x4000000u),
+        LANCE("lance", 0x8000000u),
+        ANTI_BRAWLER("anti_brawler", 0x10000000u),
+        ANTI_SHAPE_SHIFTER("anti_shape_shifter", 0x20000000u),
+        BOW("bow", 0x40000000u),
+        ANTI_SMITHY("anti_smithy", 0x400000000u),
+        CURSED("cursed", 0x2000000000000000u);
 
         companion object {
-            fun fromInt(value: Int) = values().filter { value.and(it.bit) != 0 }.toMutableSet()
+            fun toSet(value: ULong) = values().filter { value.and(it.bit) != 0uL }.toMutableSet()
         }
     }
 
     enum class WearFlag(
             @JsonValue val tag: String,
-            val bit: Int
+            val bit: ULong
     ) {
-        TAKE("take", 0x1),
-        WEAR_FINGER("wear_finger", 0x2),
-        WEAR_NECK("wear_neck", 0x4),
-        WEAR_BODY("wear_body", 0x8),
-        WEAR_HEAD("wear_head", 0x10),
-        WEAR_LEGS("wear_legs", 0x20),
-        WEAR_FEET("wear_feet", 0x40),
-        WEAR_HANDS("wear_hands", 0x80),
-        WEAR_ARMS("wear_arms", 0x100),
-        WEAR_SHIELD("wear_shield", 0x200),
-        WEAR_ABOUT_BODY("wear_about_body", 0x400),
-        WEAR_WAIST("wear_waist", 0x800),
-        WEAR_WRIST("wear_wrist", 0x1000),
-        WIELD("wield", 0x2000),
-        HOLD("hold", 0x4000),
-        FLOAT("float", 0x8000),
-        WEAR_POUCH("wear_pouch", 0x10000),
-        RANGED_WEAPON("ranged_weapon", 0x20000),
-        SIZE_ALL("size_all", 0x8000000),
-        SIZE_SMALL("size_small", 0x10000000),
-        SIZE_MEDIUM("size_medium", 0x20000000),
-        SIZE_LARGE("size_large", 0x40000000);
+        TAKE("take", 0x1u),
+        WEAR_FINGER("wear_finger", 0x2u),
+        WEAR_NECK("wear_neck", 0x4u),
+        WEAR_BODY("wear_body", 0x8u),
+        WEAR_HEAD("wear_head", 0x10u),
+        WEAR_LEGS("wear_legs", 0x20u),
+        WEAR_FEET("wear_feet", 0x40u),
+        WEAR_HANDS("wear_hands", 0x80u),
+        WEAR_ARMS("wear_arms", 0x100u),
+        WEAR_SHIELD("wear_shield", 0x200u),
+        WEAR_ABOUT_BODY("wear_about_body", 0x400u),
+        WEAR_WAIST("wear_waist", 0x800u),
+        WEAR_WRIST("wear_wrist", 0x1000u),
+        WIELD("wield", 0x2000u),
+        HOLD("hold", 0x4000u),
+        FLOAT("float", 0x8000u),
+        WEAR_POUCH("wear_pouch", 0x10000u),
+        RANGED_WEAPON("ranged_weapon", 0x20000u),
+        SIZE_ALL("size_all", 0x8000000u),
+        SIZE_SMALL("size_small", 0x10000000u),
+        SIZE_MEDIUM("size_medium", 0x20000000u),
+        SIZE_LARGE("size_large", 0x40000000u);
 
         companion object {
-            fun fromInt(value: Int) = values().filter { value.and(it.bit) != 0 }.toSet()
+            fun toSet(value: ULong) = values().filter { value.and(it.bit) != 0uL }.toSet()
         }
     }
 

--- a/core/src/main/kotlin/dd4/core/model/ItemSet.kt
+++ b/core/src/main/kotlin/dd4/core/model/ItemSet.kt
@@ -1,0 +1,7 @@
+package dd4.core.model
+
+// Avoid using the class name "ObjectSet" as we want to be consistent with our own model, which cannot use "Object".
+//TODO: Model is incomplete
+data class ItemSet(
+        val vnum: Int,
+)

--- a/core/src/main/kotlin/dd4/core/model/Mobile.kt
+++ b/core/src/main/kotlin/dd4/core/model/Mobile.kt
@@ -39,93 +39,98 @@ data class Mobile(
 
     enum class ActFlag(
             @JsonValue val tag: String,
-            val bit: Int
+            val bit: ULong
     ) {
-        NPC("npc", 0x1),
-        SENTINEL("sentinel", 0x2),
-        SCAVENGER("scavenger", 0x4),
-        QUEST_MASTER("quest_master", 0x8),
-        AGGRESSIVE("aggressive", 0x20),
-        STAY_AREA("stay_area", 0x40),
-        WIMPY("wimpy", 0x80),
-        PET("pet", 0x100),
-        NO_QUEST("no_quest", 0x200),
-        PRACTICE("practice", 0x400),
-        GAMBLE("gamble", 0x800),
-        NO_CHARM("no_charm", 0x1000),
-        HEALER("healer", 0x2000),
-        FAMOUS("famous", 0x4000),
-        LOSE_FAME("lose_fame", 0x8000),
-        WIZINVIS("wizinvis", 0x10000),
-        MOUNTABLE("mountable", 0x20000),
-        BANKER("banker", 0x80000),
-        IDENTIFIER("identifier", 0x100000),
-        DIE_IF_MASTER_GONE("die_if_master_gone", 0x200000),
-        CLAN_GUARD("clan_guard", 0x400000),
-        NO_SUMMON("no_summon", 0x800000),
-        NO_EXPERIENCE("no_experience", 0x1000000);
+        NPC("npc", 0x1u),
+        SENTINEL("sentinel", 0x2u),
+        SCAVENGER("scavenger", 0x4u),
+        QUEST_MASTER("quest_master", 0x8u),
+        AGGRESSIVE("aggressive", 0x20u),
+        STAY_AREA("stay_area", 0x40u),
+        WIMPY("wimpy", 0x80u),
+        PET("pet", 0x100u),
+        NO_QUEST("no_quest", 0x200u),
+        PRACTICE("practice", 0x400u),
+        GAMBLE("gamble", 0x800u),
+        NO_CHARM("no_charm", 0x1000u),
+        HEALER("healer", 0x2000u),
+        FAMOUS("famous", 0x4000u),
+        LOSE_FAME("lose_fame", 0x8000u),
+        WIZINVIS("wizinvis", 0x10000u),
+        MOUNTABLE("mountable", 0x20000u),
+        BANKER("banker", 0x80000u),
+        IDENTIFIER("identifier", 0x100000u),
+        DIE_IF_MASTER_GONE("die_if_master_gone", 0x200000u),
+        CLAN_GUARD("clan_guard", 0x400000u),
+        NO_SUMMON("no_summon", 0x800000u),
+        NO_EXPERIENCE("no_experience", 0x1000000u),
+        UNKILLABLE("unkillable", 0x8000000000000000u);
 
         companion object {
-            fun fromInt(value: Int) = values().filter { value.and(it.bit) != 0 }.toSet()
+            fun toSet(value: ULong) = values().filter { value.and(it.bit) != 0uL }.toSet()
         }
     }
 
     enum class EffectFlag(
             @JsonValue val tag: String,
-            val bit: Int
+            val bit: ULong
     ) {
-        BLIND("blind", 0x1),
-        INVISIBLE("invisible", 0x2),
-        DETECT_EVIL("detect_evil", 0x4),
-        DETECT_INVIS("detect_invis", 0x8),
-        DETECT_MAGIC("detect_magic", 0x10),
-        DETECT_HIDDEN("detect_hidden", 0x20),
-        HOLD("hold", 0x40),
-        SANCTUARY("sanctuary", 0x80),
-        FAERIE_FIRE("faerie_fire", 0x100),
-        INFRARED("infrared", 0x200),
-        CURSE("curse", 0x400),
-        FLAMING("flaming", 0x800),
-        POISON("poison", 0x1000),
-        PROTECTION("protection", 0x2000),
-        MEDITATE("meditate", 0x4000),
-        SNEAK("sneak", 0x8000),
-        HIDE("hide", 0x10000),
-        SLEEP("sleep", 0x20000),
-        CHARM("charm", 0x40000),
-        FLYING("flying", 0x80000),
-        PASS_DOOR("pass_door", 0x100000),
-        DETECT_TRAPS("detect_traps", 0x200000),
-        BATTLE_AURA("battle_aura", 0x400000),
-        DETECT_SNEAK("detect_sneak", 0x800000),
-        GLOBE("globe", 0x1000000),
-        DETER("deter", 0x2000000),
-        SWIM("swim", 0x4000000),
-        PRAYER_PLAGUE("prayer_of_plague", 0x8000000),
-        NON_CORPOREAL("non_corporeal", 0x10000000),
-        DETECT_GOOD("detect_good", 0x40000000);
+        BLIND("blind", 0x1u),
+        INVISIBLE("invisible", 0x2u),
+        DETECT_EVIL("detect_evil", 0x4u),
+        DETECT_INVIS("detect_invis", 0x8u),
+        DETECT_MAGIC("detect_magic", 0x10u),
+        DETECT_HIDDEN("detect_hidden", 0x20u),
+        HOLD("hold", 0x40u),
+        SANCTUARY("sanctuary", 0x80u),
+        FAERIE_FIRE("faerie_fire", 0x100u),
+        INFRARED("infrared", 0x200u),
+        CURSE("curse", 0x400u),
+        FLAMING("flaming", 0x800u),
+        POISON("poison", 0x1000u),
+        PROTECTION("protection", 0x2000u),
+        MEDITATE("meditate", 0x4000u),
+        SNEAK("sneak", 0x8000u),
+        HIDE("hide", 0x10000u),
+        SLEEP("sleep", 0x20000u),
+        CHARM("charm", 0x40000u),
+        FLYING("flying", 0x80000u),
+        PASS_DOOR("pass_door", 0x100000u),
+        DETECT_TRAPS("detect_traps", 0x200000u),
+        BATTLE_AURA("battle_aura", 0x400000u),
+        DETECT_SNEAK("detect_sneak", 0x800000u),
+        GLOBE("globe", 0x1000000u),
+        DETER("deter", 0x2000000u),
+        SWIM("swim", 0x4000000u),
+        PRAYER_PLAGUE("prayer_of_plague", 0x8000000u),
+        NON_CORPOREAL("non_corporeal", 0x10000000u),
+        DETECT_GOOD("detect_good", 0x40000000u),
+        SWALLOWED("swallowed", 0x80000000u),
+        NO_RECALL("no_recall", 0x100000000u),
+        DAMAGE_OVER_TIME("damage_over_time", 0x200000000u),
+        SLOW("slow", 0x8000000000000000u);
 
         companion object {
-            fun fromInt(value: Int) = values().filter { value.and(it.bit) != 0 }.toSet()
+            fun toSet(value: ULong) = values().filter { value.and(it.bit) != 0uL }.toSet()
         }
     }
 
     enum class BodyFormFlag(
             @JsonValue val tag: String,
-            val bit: Int
+            val bit: ULong
     ) {
-        NO_HEAD("no_head", 0x1),
-        NO_EYES("no_eyes", 0x2),
-        NO_ARMS("no_arms", 0x4),
-        NO_LEGS("no_legs", 0x8),
-        NO_HEART("no_heart", 0x10),
-        NO_SPEECH("no_speech", 0x20),
-        NO_CORPSE("no_corpse", 0x40),
-        HUGE("huge", 0x80),
-        INORGANIC("inorganic", 0x100);
+        NO_HEAD("no_head", 0x1u),
+        NO_EYES("no_eyes", 0x2u),
+        NO_ARMS("no_arms", 0x4u),
+        NO_LEGS("no_legs", 0x8u),
+        NO_HEART("no_heart", 0x10u),
+        NO_SPEECH("no_speech", 0x20u),
+        NO_CORPSE("no_corpse", 0x40u),
+        HUGE("huge", 0x80u),
+        INORGANIC("inorganic", 0x100u);
 
         companion object {
-            fun fromInt(value: Int) = values().filter { value.and(it.bit) != 0 }.toSet()
+            fun toSet(value: ULong) = values().filter { value.and(it.bit) != 0uL }.toSet()
         }
     }
 

--- a/core/src/main/kotlin/dd4/core/model/Room.kt
+++ b/core/src/main/kotlin/dd4/core/model/Room.kt
@@ -14,25 +14,26 @@ data class Room(
 ) {
     enum class Flag(
             @JsonValue val tag: String,
-            val bit: Int
+            val bit: ULong
     ) {
-        DARK("dark", 0x1),
-        NO_MOB("no_mob", 0x4),
-        INDOORS("indoors", 0x8),
-        PRIVATE("private", 0x200),
-        SAFE("safe", 0x400),
-        SOLITARY("solitary", 0x800),
-        PET_SHOP("pet_shop", 0x1000),
-        NO_RECALL("no_recall", 0x2000),
-        CONE_OF_SILENCE("cone_of_silence", 0x4000),
-        PLAYER_KILLER("player_killer", 0x8000),
-        HEALING("healing", 0x10000),
-        FREEZING("freezing", 0x20000),
-        BURNING("burning", 0x40000),
-        NO_MOUNT("no_mount", 0x80000);
+        DARK("dark", 0x1u),
+        NO_MOB("no_mob", 0x4u),
+        INDOORS("indoors", 0x8u),
+        PRIVATE("private", 0x200u),
+        SAFE("safe", 0x400u),
+        SOLITARY("solitary", 0x800u),
+        PET_SHOP("pet_shop", 0x1000u),
+        NO_RECALL("no_recall", 0x2000u),
+        CONE_OF_SILENCE("cone_of_silence", 0x4000u),
+        PLAYER_KILLER("player_killer", 0x8000u),
+        HEALING("healing", 0x10000u),
+        FREEZING("freezing", 0x20000u),
+        BURNING("burning", 0x40000u),
+        NO_MOUNT("no_mount", 0x80000u),
+        NO_DROP("no_drop", 0x8000000000000000u);
 
         companion object {
-            fun fromInt(value: Int) = values().filter { value.and(it.bit) != 0 }.toSet()
+            fun toSet(value: ULong) = values().filter { value.and(it.bit) != 0uL }.toSet()
         }
     }
 

--- a/core/src/main/kotlin/dd4/core/model/Section.kt
+++ b/core/src/main/kotlin/dd4/core/model/Section.kt
@@ -10,12 +10,14 @@ enum class Section(
     MOBILES("MOBILES"),
     MOBPROGS("MOBPROGS"),
     OBJECTS("OBJECTS"),
+    OBJECT_SETS("OBJECT_SETS"),
     ROOMS("ROOMS"),
     RESETS("RESETS"),
     SHOPS("SHOPS"),
     SPECIAL_FUNCTIONS("SPECIALS"),
     HELPS("HELPS"),
     RECALL("RECALL"),
+    GAMES("GAMES"),
     END_OF_FILE("$");
 
     companion object {

--- a/core/src/main/kotlin/dd4/core/model/SourceFile.kt
+++ b/core/src/main/kotlin/dd4/core/model/SourceFile.kt
@@ -11,11 +11,13 @@ data class SourceFile (
         val mobProgAssignments: List<MobProgAssignment> = mutableListOf(),
         val mobProgFiles: List<MobProgFile> = mutableListOf(),
         val objects: List<Item> = mutableListOf(),
+        val objectSets: List<ItemSet> = mutableListOf(),
         val rooms: List<Room> = mutableListOf(),
         val resets: List<Reset> = mutableListOf(),
         val shops: List<Shop> = mutableListOf(),
         val specialFunctions: List<SpecialFunction> = mutableListOf(),
         val helps: List<Help> = mutableListOf(),
+        val games: List<Game> = mutableListOf(),
 ) {
     override fun toString(): String {
         return "SourceFile(id='$id', fileName='$fileName')"
@@ -27,6 +29,8 @@ data class SourceFile (
 
     fun addObjects(toAdd: Collection<Item>) = (objects as MutableList).addAll(toAdd)
 
+    fun addObjectSets(toAdd: Collection<ItemSet>) = (objectSets as MutableList).addAll(toAdd)
+
     fun addRooms(toAdd: Collection<Room>) = (rooms as MutableList).addAll(toAdd)
 
     fun addResets(toAdd: Collection<Reset>) = (resets as MutableList).addAll(toAdd)
@@ -36,6 +40,8 @@ data class SourceFile (
     fun addSpecialFunctions(toAdd: Collection<SpecialFunction>) = (specialFunctions as MutableList).addAll(toAdd)
 
     fun addHelps(toAdd: Collection<Help>) = (helps as MutableList).addAll(toAdd)
+
+    fun addGames(toAdd: Collection<Game>) = (games as MutableList).addAll(toAdd)
 
     fun addMobProgFiles(toAdd: Collection<MobProgFile>) {
         toAdd.forEach { mobProgFile ->


### PR DESCRIPTION
Convert bitvector-based flag fields to the unsigned long type.
dd4 now uses a longer integer type to allow more flags.

Consume new OBJECT_SETS and GAMES area files sections.
Note that these sections aren't fully modelled yet: we only want to
be able to read the latest versions of area files without parsing
errors.