### PR TITLE
Remove new colour escapes from map room descriptions

### DIFF
--- a/core/src/main/kotlin/dd4/core/model/Room.kt
+++ b/core/src/main/kotlin/dd4/core/model/Room.kt
@@ -95,7 +95,9 @@ data class Room(
 
     @get:JsonIgnore
     val cleanName: String
-        get() = this.name.replace(Regex("[{}]."), "")
+        get() = this.name
+                .replace(Regex("[{}]."), "")
+                .replace(Regex("<[^>]*>"), "")
 
     fun exit(direction: Direction) = exits[direction]
 


### PR DESCRIPTION
New `<...>` based escape sequences are now being used in room names and descriptions. Strip these from names rendered on maps.