### PR TITLE
Better reporting of parsing errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,15 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 ij_continuation_indent_size = 8
+max_line_length = 120
+
+[*.{kt,kts}]
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_else_on_new_line = true
+ij_kotlin_catch_on_new_line = true
+ij_kotlin_finally_on_new_line = true
+ij_kotlin_name_count_to_use_star_import = 100
 
 [{*.json,*.yml,*.yaml}]
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@
 build/
 out/
 output/
-/sample-data/area/
-/sample-data/

--- a/area-parser/src/main/kotlin/dd4/areaparser/AreaFileReader.kt
+++ b/area-parser/src/main/kotlin/dd4/areaparser/AreaFileReader.kt
@@ -92,7 +92,7 @@ class AreaFileReader(areaFilePath: Path) : Closeable {
     fun readString(): String {
         readWhitespace()
         val word = readWhile { it != Markup.STRING_DELIMITER }
-        readChar() ?: throw ParseError("Unterminated string: '${snippet(word)}")
+        readChar() ?: throw ParseError("Unterminated string: '${snippet(word)}", this)
         return word
     }
 
@@ -105,14 +105,18 @@ class AreaFileReader(areaFilePath: Path) : Closeable {
 
         val unparsed = firstChar + readWhile { it.isDigit() || it == Markup.BIT_DELIMITER }
 
-        if (unparsed.contains(Markup.BIT_DELIMITER)) {
-            return unparsed.split(Markup.BIT_DELIMITER)
-                    .filter { it.isNotBlank() }
-                    .map { it.toInt() }
-                    .sum()
-        }
+        try {
+            if (unparsed.contains(Markup.BIT_DELIMITER)) {
+                return unparsed.split(Markup.BIT_DELIMITER)
+                        .filter { it.isNotBlank() }
+                        .sumOf { it.toInt() }
+            }
 
-        return unparsed.toInt()
+            return unparsed.toInt()
+        }
+        catch (e: Exception) {
+            throw ParseError("Unable to read number from value '$unparsed' (too large?)", this, e)
+        }
     }
 
     fun readBits(): ULong {
@@ -131,7 +135,12 @@ class AreaFileReader(areaFilePath: Path) : Closeable {
                     .sum()
         }
 
-        return unparsed.toULong()
+        return try {
+            unparsed.toULong()
+        }
+        catch (e: Exception) {
+            throw ParseError("Unable to read bits from value '$unparsed' (too large?)", this, e)
+        }
     }
 
     fun readLetter(): Char {

--- a/area-parser/src/main/kotlin/dd4/areaparser/AreaFileReader.kt
+++ b/area-parser/src/main/kotlin/dd4/areaparser/AreaFileReader.kt
@@ -128,15 +128,14 @@ class AreaFileReader(areaFilePath: Path) : Closeable {
 
         val unparsed = firstChar + readWhile { it.isDigit() || it == Markup.BIT_DELIMITER }
 
-        if (unparsed.contains(Markup.BIT_DELIMITER)) {
-            return unparsed.split(Markup.BIT_DELIMITER)
-                    .filter { it.isNotBlank() }
-                    .map { it.toULong() }
-                    .sum()
-        }
+        try {
+            if (unparsed.contains(Markup.BIT_DELIMITER)) {
+                return unparsed.split(Markup.BIT_DELIMITER)
+                        .filter { it.isNotBlank() }
+                        .sumOf { it.toULong() }
+            }
 
-        return try {
-            unparsed.toULong()
+            return unparsed.toULong()
         }
         catch (e: Exception) {
             throw ParseError("Unable to read bits from value '$unparsed' (too large?)", this, e)

--- a/area-parser/src/main/kotlin/dd4/areaparser/ParseError.kt
+++ b/area-parser/src/main/kotlin/dd4/areaparser/ParseError.kt
@@ -11,8 +11,8 @@ class ParseError(message: String, e: Exception?) : RuntimeException(message, e) 
 
     constructor(message: String) : this(message, null)
 
-    constructor(message: String, reader: AreaFileReader) : this("$message (context: ${readerContext(reader)})")
+    constructor(message: String, reader: AreaFileReader) : this(message, reader, null)
 
-    constructor(message: String, reader: AreaFileReader, e: Exception) :
+    constructor(message: String, reader: AreaFileReader, e: Exception?) :
             this("$message (context: ${readerContext(reader)})", e)
 }

--- a/area-parser/src/main/kotlin/dd4/areaparser/ParseError.kt
+++ b/area-parser/src/main/kotlin/dd4/areaparser/ParseError.kt
@@ -1,6 +1,6 @@
 package dd4.areaparser
 
-class ParseError(message: String) : RuntimeException(message) {
+class ParseError(message: String, e: Exception?) : RuntimeException(message, e) {
 
     companion object {
         fun readerContext(reader: AreaFileReader) =
@@ -9,5 +9,10 @@ class ParseError(message: String) : RuntimeException(message) {
                         .replace("\n", "\\n")
     }
 
+    constructor(message: String) : this(message, null)
+
     constructor(message: String, reader: AreaFileReader) : this("$message (context: ${readerContext(reader)})")
+
+    constructor(message: String, reader: AreaFileReader, e: Exception) :
+            this("$message (context: ${readerContext(reader)})", e)
 }

--- a/sample-data/.gitignore
+++ b/sample-data/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md


### PR DESCRIPTION
Provide more context when the area file parser has trouble working with
numbers or bit arrays.

Tweak editorconfig and gitignore.


