### PR TITLE
Exclude hidden areas from map making

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Creates static HTML maps from parsed area files.
 **NOTE:** These maps are far from perfect and have various layout issues.
 However, they are generally "good enough". Lots to improve here!
 
+Some areas are excluded from the map making process, including clan headquarters and "hidden" areas.
+"Hidden" areas are typically not able to be directly explored by players: they are usually just containers
+for special objects and mobs.
+
 ### Area Query
 
 Generates a specialised area entity database for use in an external query tool.

--- a/area-query/src/main/kotlin/dd4/areaquery/QueryDbGenerator.kt
+++ b/area-query/src/main/kotlin/dd4/areaquery/QueryDbGenerator.kt
@@ -255,7 +255,7 @@ class QueryDbGenerator(
             currentLevelForItemLookup[itemVnum] = currentItemLevel
         }
 
-        if (areaSpecial?.flags?.contains(AreaSpecial.AreaFlag.AREA_FLAG_SCHOOL) == true
+        if (areaSpecial?.isFlagged(AreaSpecial.AreaFlag.SCHOOL) == true
                 && currentItemLevel <= SCHOOL_LEVEL_MAX) {
             levelMin = 1
             levelMax = 1

--- a/core/src/main/kotlin/dd4/core/model/AreaSpecial.kt
+++ b/core/src/main/kotlin/dd4/core/model/AreaSpecial.kt
@@ -9,12 +9,12 @@ data class AreaSpecial(
     enum class AreaFlag(
             @JsonValue val tag: String,
     ) {
-        AREA_FLAG_SCHOOL("school"),
-        AREA_FLAG_NO_QUEST("no_quest"),
-        AREA_FLAG_HIDDEN("hidden"),
-        AREA_FLAG_SAFE("safe"),
-        AREA_FLAG_NO_TELEPORT("no_teleport"),
-        AREA_FLAG_NO_MAGIC("no_magic");
+        SCHOOL("school"),
+        NO_QUEST("no_quest"),
+        HIDDEN("hidden"),
+        SAFE("safe"),
+        NO_TELEPORT("no_teleport"),
+        NO_MAGIC("no_magic");
 
         companion object {
             fun fromTag(value: String) =
@@ -28,4 +28,6 @@ data class AreaSpecial(
             fun findByTag(value: String) = values().find { it.tag == value }
         }
     }
+
+    fun isFlagged(flag: AreaFlag): Boolean = flags.contains(flag)
 }

--- a/map-maker/src/main/kotlin/dd4/mapmaker/MapMaker.kt
+++ b/map-maker/src/main/kotlin/dd4/mapmaker/MapMaker.kt
@@ -1,6 +1,7 @@
 package dd4.mapmaker
 
 import dd4.core.file.AreaFileMapper
+import dd4.core.model.AreaSpecial
 import dd4.mapmaker.model.AreaMap
 import dd4.mapmaker.model.RoomAndArea
 import dd4.mapmaker.render.HtmlRenderer
@@ -17,7 +18,7 @@ class MapMaker(
         private val areaIds: List<String> = listOf(),
 ) {
     companion object {
-        const val VERSION = "0.2"
+        const val VERSION = "0.3"
     }
 
     fun generate() {
@@ -25,7 +26,8 @@ class MapMaker(
 
         val allAreaFiles = areaFileMapper.readFromFile(areaFileName)
                 .filter { it.area != null }
-                .filter { it.area?.isClanHeadquarters() == false }
+                .filter { it.area?.isClanHeadquarters() != true }
+                .filter { it.areaSpecial?.isFlagged(AreaSpecial.AreaFlag.HIDDEN) != true }
                 .filter { it.rooms.isNotEmpty() }
 
         val areaFilesToMap = allAreaFiles


### PR DESCRIPTION
Don't include hidden areas when building maps. These include dummy areas used for quests, special item/mob definitions, and so on.