### PR TITLE
Filter out more invalid spell IDs.

### DIFF
--- a/area-parser/src/main/kotlin/dd4/areaparser/AreaParser.kt
+++ b/area-parser/src/main/kotlin/dd4/areaparser/AreaParser.kt
@@ -554,7 +554,11 @@ class AreaParser(
         return properties
     }
 
-    private fun validSpells(vararg spells: String) = spells.filter { it.isNotBlank() && it != "0" }
+    private fun validSpells(vararg spells: String) = spells.filter {
+        it.isNotBlank() &&
+            it != "0" &&
+            it != "-1"
+    }
 
     private fun parseRoomsSection(sourceFile: SourceFile, reader: AreaFileReader): List<Room> {
         val rooms = mutableListOf<Room>()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,4 @@
 object Versions {
-    const val kotlin_jvm_target = "21"
-    const val kotlin_api = "2.1"
     const val jackson = "2.11.1"
     const val kotlinx_cli = "0.3.4"
     const val freemarker = "2.3.30"


### PR DESCRIPTION
Filter out more invalid spell IDs. -1 is used as a placeholder for "no spell".